### PR TITLE
feat: add upload file from URL functionality

### DIFF
--- a/nodes/Postiz/Postiz.node.ts
+++ b/nodes/Postiz/Postiz.node.ts
@@ -765,11 +765,16 @@ export class Postiz implements INodeType {
 
 				if (operation === 'uploadFileFromURL') {
 					const url = this.getNodeParameter('url', i) as string;
-					// Check if it's a valid URL
-					if (!url.startsWith('http://') && !url.startsWith('https://')) {
+					// Validate URL format
+					try {
+						const parsedUrl = new URL(url);
+						if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+							throw new Error('Invalid protocol');
+						}
+					} catch {
 						throw new NodeOperationError(
 							this.getNode(),
-							`URL is not a valid URL: ${url}`,
+							`Invalid URL format: ${url}. Please provide a valid HTTP or HTTPS URL.`,
 							{ itemIndex: i },
 						);
 					}

--- a/nodes/Postiz/Postiz.node.ts
+++ b/nodes/Postiz/Postiz.node.ts
@@ -765,19 +765,27 @@ export class Postiz implements INodeType {
 
 				if (operation === 'uploadFileFromURL') {
 					const url = this.getNodeParameter('url', i) as string;
-					// Validate URL format
+					
+					// Validate URL format and protocol
+					let parsedUrl;
 					try {
-						const parsedUrl = new URL(url);
-						if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-							throw new Error('Invalid protocol');
-						}
-					} catch {
+						parsedUrl = new URL(url);
+					} catch (error) {
 						throw new NodeOperationError(
 							this.getNode(),
 							`Invalid URL format: ${url}. Please provide a valid HTTP or HTTPS URL.`,
 							{ itemIndex: i },
 						);
 					}
+					
+					if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+						throw new NodeOperationError(
+							this.getNode(),
+							`Invalid URL protocol: ${parsedUrl.protocol}. Only HTTP and HTTPS URLs are supported.`,
+							{ itemIndex: i },
+						);
+					}
+					
 					responseData = await postizApiRequest.call(this, 'POST', '/upload-from-url', { url });
 				}
 

--- a/nodes/Postiz/Postiz.node.ts
+++ b/nodes/Postiz/Postiz.node.ts
@@ -41,7 +41,7 @@ export class Postiz implements INodeType {
 						name: 'Create Post',
 						value: 'createPost',
 						description: 'Schedule a post to Postiz',
-						action: 'Schedule a post to Postiz',
+						action: 'Schedule a post to postiz',
 					},
 					{
 						name: 'Delete Post',
@@ -71,13 +71,13 @@ export class Postiz implements INodeType {
 						name: 'Upload File',
 						value: 'uploadFile',
 						description: 'Upload a file to Postiz',
-						action: 'Upload a file to Postiz',
+						action: 'Upload a file to postiz',
 					},
 					{
-						name: 'Upload File from URL',
+						name: 'Upload File From URL',
 						value: 'uploadFileFromURL',
 						description: 'Upload a file to Postiz from URL',
-						action: 'Upload a file to Postiz from URL',
+						action: 'Upload a file to postiz from url',
 					},
 					{
 						name: 'Video Function',

--- a/nodes/Postiz/Postiz.node.ts
+++ b/nodes/Postiz/Postiz.node.ts
@@ -41,7 +41,7 @@ export class Postiz implements INodeType {
 						name: 'Create Post',
 						value: 'createPost',
 						description: 'Schedule a post to Postiz',
-						action: 'Schedule a post to postiz',
+						action: 'Schedule a post to Postiz',
 					},
 					{
 						name: 'Delete Post',
@@ -71,13 +71,13 @@ export class Postiz implements INodeType {
 						name: 'Upload File',
 						value: 'uploadFile',
 						description: 'Upload a file to Postiz',
-						action: 'Upload a file to postiz',
+						action: 'Upload a file to Postiz',
 					},
 					{
 						name: 'Upload File from URL',
 						value: 'uploadFileFromURL',
 						description: 'Upload a file to Postiz from URL',
-						action: 'Upload a file to postiz from URL',
+						action: 'Upload a file to Postiz from URL',
 					},
 					{
 						name: 'Video Function',

--- a/nodes/Postiz/Postiz.node.ts
+++ b/nodes/Postiz/Postiz.node.ts
@@ -74,6 +74,12 @@ export class Postiz implements INodeType {
 						action: 'Upload a file to postiz',
 					},
 					{
+						name: 'Upload File from URL',
+						value: 'uploadFileFromURL',
+						description: 'Upload a file to Postiz from URL',
+						action: 'Upload a file to postiz from URL',
+					},
+					{
 						name: 'Video Function',
 						value: 'videoFunction',
 						description: 'Execute video-related functions like loading voices',
@@ -591,6 +597,20 @@ export class Postiz implements INodeType {
 				required: true,
 				description: 'Name of the binary property that contains the file data',
 			},
+			// UploadFileFromURL parameters
+			{
+				displayName: 'URL',
+				name: 'url',
+				type: 'string',
+				displayOptions: {
+					show: {
+						operation: ['uploadFileFromURL'],
+					},
+				},
+				default: '',
+				required: true,
+				description: 'URL of the file to upload',
+			},
 			// DeletePost parameters
 			{
 				displayName: 'Post ID',
@@ -741,6 +761,19 @@ export class Postiz implements INodeType {
 					const formData = new FormData();
 					formData.append('file', blob, binaryData.fileName);
 					responseData = await postizApiRequest.call(this, 'POST', '/upload', formData);
+				}
+
+				if (operation === 'uploadFileFromURL') {
+					const url = this.getNodeParameter('url', i) as string;
+					// Check if it's a valid URL
+					if (!url.startsWith('http://') && !url.startsWith('https://')) {
+						throw new NodeOperationError(
+							this.getNode(),
+							`URL is not a valid URL: ${url}`,
+							{ itemIndex: i },
+						);
+					}
+					responseData = await postizApiRequest.call(this, 'POST', '/upload-from-url', { url });
 				}
 
 				if (operation === 'getIntegrations') {


### PR DESCRIPTION
# What kind of change does this PR introduce?

This PR adds the ability to upload files from URLs to Postiz, like it's documented in the API documentation.
https://docs.postiz.com/public-api#upload-a-new-file-from-an-existing-url

# Why was this change needed?

Currently, the only way to upload files to Postiz in n8n is by using a custom http request node.

# Other information:

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Upload File from URL" to Postiz — upload files directly from web URLs with a required URL field and client-side URL format and protocol validation.

* **Bug Fixes**
  * Corrected action label capitalization for existing Postiz actions ("Schedule a post to Postiz" and "Upload a file to Postiz").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->